### PR TITLE
bugfix: links in docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,10 +10,10 @@ _Please consider to install docker and docker-compose on your own for your speci
 
 For the environment, four things should be running: Envoy proxy, MongoDB replicas, Redis, and RabbitMQ.
 
-1. Copy [Envoy proxy config](backend/envoy.yaml) file
-2. Copy [Public service catalog transcoder](backend/public-service-catalog.pb) file
-3. Copy [Criminal service catalog transcoder](backend/criminal-cert-service.pb) file
-4. Copy [docker-compose](backend/docker-compose.yaml) file
+1. Copy [Envoy proxy config](./envoy.yaml) file
+2. Copy [Public service catalog transcoder](./public-service-catalog.pb) file
+3. Copy [Criminal service catalog transcoder](./criminal-cert-service.pb) file
+4. Copy [docker-compose](./docker-compose.yml) file
 5. Run the following commands from the folder containing compose file:
 ```bash
 sudo -- sh -c -e "echo '127.0.0.1	mongo1 mongo2 mongo3' >> /etc/hosts"


### PR DESCRIPTION
Hello, diia developers

I would like to fix links in docs https://github.com/diia-open-source/diia-setup-howto/blob/main/backend/README.md. 

**Current behaviour:**
Users can't navigate through docs using links in README file, because links navigate to non-existent files, here is the demo:

https://github.com/diia-open-source/diia-setup-howto/assets/60394886/27a025bc-049c-4e91-8981-1a28fe620e5c

**What was done:**
- Fixed links in README, so now users can in more convenient way access files from the README

